### PR TITLE
Limit duration output precision

### DIFF
--- a/src/util/chrono.rs
+++ b/src/util/chrono.rs
@@ -6,6 +6,6 @@ pub fn format_duration(duration: Duration) -> String {
     if duration.as_secs() < 1 {
         format!("{}ms", duration.as_millis())
     } else {
-        format!("{}s", duration.as_secs_f64())
+        format!("{:.3}s", duration.as_secs_f64())
     }
 }


### PR DESCRIPTION
## Summary
- show only 3 decimal places when printing seconds

## Testing
- `cargo build`
- `cargo test --quiet`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_685b18da4b2883248e1177f8d2da72b1