### PR TITLE
Add mouse scroll support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The name *Boda* (보다) comes from the Korean verb meaning "to watch" or "to se
 - Navigate between historical outputs.
 - Persist command output into a SQLite database.
 - Run commands **concurrently**.
+- Scroll output with the mouse wheel.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- support scrolling via mouse wheel
- enable and disable mouse capture
- document mouse scroll support

## Testing
- `cargo fmt -- --check`
- `cargo test --quiet`
- `cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685b1b9ff1b0832481d61d096d8133b9