### PR TITLE
Run UI and command state handlers in parallel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,11 @@ fn main() -> error::BodaResult<()> {
     let (command_manger, command_action_rx) = command::manager::Manager::new();
     let (ui_manager, ui_action_rx) = ui::manager::Manager::new();
 
-    let handles = [
-        command_manger.run(state_manager.state.clone()),
-        ui_manager.run(state_manager.state.clone()),
-        state_manager.run(ui_action_rx, command_action_rx),
-    ];
+    let command_handle = command_manger.run(state_manager.state.clone());
+    let ui_handle = ui_manager.run(state_manager.state.clone());
+    let (ui_state_handle, command_state_handle) =
+        state_manager.run(ui_action_rx, command_action_rx);
+    let handles = [command_handle, ui_handle, ui_state_handle, command_state_handle];
     for handle in handles {
         handle.join().expect("unable to join thread");
     }


### PR DESCRIPTION
## Summary
- spawn separate threads for handling UI and command state actions
- return state manager thread handles as a tuple
- update main to join the two state threads along with UI and command manager threads

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685b1fac9bf4832495f4f458b14cb6ca