### PR TITLE
Spawn separate threads for command/ui state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,17 @@ fn main() -> error::BodaResult<()> {
     let (command_manger, command_action_rx) = command::manager::Manager::new();
     let (ui_manager, ui_action_rx) = ui::manager::Manager::new();
 
+    let command_handle = command_manger.run(state_manager.state.clone());
+    let ui_handle = ui_manager.run(state_manager.state.clone());
+    let (ui_state_handle, command_state_handle) =
+        state_manager.run(ui_action_rx, command_action_rx);
     let handles = [
-        command_manger.run(state_manager.state.clone()),
-        ui_manager.run(state_manager.state.clone()),
-        state_manager.run(ui_action_rx, command_action_rx),
+        command_handle,
+        ui_handle,
+        ui_state_handle,
+        command_state_handle,
     ];
+
     for handle in handles {
         handle.join().expect("unable to join thread");
     }


### PR DESCRIPTION
## Summary
- spawn dedicated threads for UI and command state actions
- return both state thread handles and join them in main
- replace busy-waiting loops with `select!`-based receivers

## Testing
- `cargo fmt`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685b232b47088324bc083915ec713d7f