### PR TITLE
Improve result pane scroll responsiveness

### DIFF
--- a/journal/2026-03-18/fix_scroll_lag.md
+++ b/journal/2026-03-18/fix_scroll_lag.md
@@ -1,0 +1,5 @@
+# Fix result scrolling lag
+
+- Investigated the result-pane `j`/`k` navigation lag in the TUI.
+- Root cause: the UI thread only handled one input event per 100ms render tick and used a bounded UI action channel, which could block on repeated key presses.
+- Fix approach: switch the UI action channel to unbounded, increase the UI refresh cadence, and drain all pending crossterm events each frame so held/repeated keys are processed promptly.

--- a/src/ui/manager.rs
+++ b/src/ui/manager.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use crossbeam_channel::{bounded, select, tick};
+use crossbeam_channel::{select, tick, unbounded};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, poll};
 use log::{debug, error};
 use ratatui::{
@@ -24,7 +24,7 @@ pub struct Manager {
 
 impl Manager {
     pub fn new() -> (Manager, crossbeam_channel::Receiver<state::action::Ui>) {
-        let (tx, rx) = bounded::<state::action::Ui>(1);
+        let (tx, rx) = unbounded::<state::action::Ui>();
 
         (Manager { action_tx: tx }, rx)
     }
@@ -34,7 +34,7 @@ impl Manager {
     pub fn run(mut self, state: Arc<RwLock<state::state::State>>) -> thread::JoinHandle<()> {
         thread::spawn(move || {
             let mut terminal = setup_terminal();
-            let ticker = tick(Duration::from_millis(100));
+            let ticker = tick(Duration::from_millis(16));
 
             loop {
                 select! {
@@ -46,8 +46,8 @@ impl Manager {
                         }
 
                         terminal.draw(|frame| self.render(frame, &state)).unwrap();
-                        if poll(Duration::from_secs(0)).unwrap() {
-                            self.handle_crossterm_events().unwrap()
+                        while poll(Duration::from_secs(0)).unwrap() {
+                            self.handle_crossterm_events().unwrap();
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation
- The result-pane scrolling with `j`/`k` felt laggy because the UI only processed one input event per 100ms tick and used a bounded action channel that could become a bottleneck for repeated keypresses.

### Description
- Switch the UI action channel from a bounded channel to an unbounded channel in `src/ui/manager.rs` to avoid blocking on repeated keypresses.
- Increase the UI tick rate from `100ms` to `16ms` in `src/ui/manager.rs` to reduce perceived input latency.
- Drain all pending crossterm events each frame by replacing the single `poll` check with a `while poll(...)` loop in `src/ui/manager.rs` so held/repeated keys are handled promptly.
- Add a journal entry at `journal/2026-03-18/fix_scroll_lag.md` documenting the investigation, root cause, and fix approach.

### Testing
- Ran `cargo test`, which completed successfully (no failing tests). 
- Ran `cargo check`, which completed successfully (build passed checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baae1df71483248b7bf512569426f6)