### PR TITLE
feat(ui): support Ctrl+U / Ctrl+D scrolling

### DIFF
--- a/journal/2026-04-13/add_ctrl_u_ctrl_d_scroll.md
+++ b/journal/2026-04-13/add_ctrl_u_ctrl_d_scroll.md
@@ -1,0 +1,12 @@
+# Add Ctrl+U / Ctrl+D scroll support
+
+## Summary
+- Added new UI actions `ScrollHalfUp` and `ScrollHalfDown`.
+- Wired keyboard shortcuts:
+  - `Ctrl+d` => scroll down by 10 lines
+  - `Ctrl+u` => scroll up by 10 lines
+- Updated help overlay keybinding text.
+
+## Notes
+- Implemented as fixed 10-line jumps because UI action handling does not currently receive viewport height.
+- Scroll movement is bounded safely with saturating math to avoid underflow/overflow.

--- a/src/state/action.rs
+++ b/src/state/action.rs
@@ -16,6 +16,8 @@ pub enum Ui {
 
     ScrollDown,
     ScrollUp,
+    ScrollHalfDown,
+    ScrollHalfUp,
 }
 
 #[derive(Debug)]

--- a/src/state/manager.rs
+++ b/src/state/manager.rs
@@ -95,6 +95,26 @@ impl Manager {
 
                 state.ui.vertical_scroll += 1;
             }
+            action::Ui::ScrollHalfDown => {
+                let length = match state
+                    .global
+                    .get_target_command_result(&state.ui.target_command)
+                {
+                    Some(r) => r.get_content().len(),
+                    _ => return,
+                };
+
+                if length == 0 {
+                    return;
+                }
+
+                let max_scroll = (length - 1) as u16;
+                state.ui.vertical_scroll =
+                    state.ui.vertical_scroll.saturating_add(10).min(max_scroll);
+            }
+            action::Ui::ScrollHalfUp => {
+                state.ui.vertical_scroll = state.ui.vertical_scroll.saturating_sub(10);
+            }
             action::Ui::ToggleShowHistory => {
                 state.ui.show_history = !state.ui.show_history;
             }

--- a/src/ui/manager.rs
+++ b/src/ui/manager.rs
@@ -80,6 +80,16 @@ impl Manager {
             (_, KeyCode::Char('k')) => {
                 self.action_tx.send(state::action::Ui::ScrollUp).unwrap();
             }
+            (KeyModifiers::CONTROL, KeyCode::Char('d') | KeyCode::Char('D')) => {
+                self.action_tx
+                    .send(state::action::Ui::ScrollHalfDown)
+                    .unwrap();
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('u') | KeyCode::Char('U')) => {
+                self.action_tx
+                    .send(state::action::Ui::ScrollHalfUp)
+                    .unwrap();
+            }
             (_, KeyCode::Char(' ')) => {
                 self.action_tx
                     .send(state::action::Ui::ToggleShowHistory)
@@ -116,6 +126,8 @@ impl Manager {
 q: Quit
 j: Scroll Down
 k: Scroll Up
+Ctrl+d: Half-page Down
+Ctrl+u: Half-page Up
 <Space>: Show History
 p: Show previous
 n: Show next


### PR DESCRIPTION
### Motivation
- Provide half-page navigation via common keybindings `Ctrl+u` and `Ctrl+d` so users can move faster through long command output.
- Implement a simple, safe jump behavior because the UI event handler does not have access to the viewport height yet.

### Description
- Added new UI actions `ScrollHalfUp` and `ScrollHalfDown` in `src/state/action.rs`.
- Mapped `Ctrl+d` and `Ctrl+u` to those actions in the input handler in `src/ui/manager.rs`.
- Implemented bounded 10-line jump scrolling in `src/state/manager.rs` using `saturating_*` and a `min` cap to avoid underflow/overflow when changing `state.ui.vertical_scroll`.
- Updated the in-app help overlay text to document `Ctrl+d` and `Ctrl+u`, and recorded the change notes in `journal/2026-04-13/add_ctrl_u_ctrl_d_scroll.md`.

### Testing
- Ran `cargo fmt --all`, which completed successfully.
- Ran `cargo test`, which finished successfully (test suite ran/finished without failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc564928448324882d6eb5a0cc77b8)